### PR TITLE
Guess image format based on content, not filename

### DIFF
--- a/crates/renderer/src/background/asset.rs
+++ b/crates/renderer/src/background/asset.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::Arc};
 
-use image::RgbaImage;
+use image::{ImageReader, RgbaImage};
 
 use super::{
     BackgroundAsset, BackgroundKind, BackgroundTreatment, GeneratedBackground, RenderCacheSummary,
@@ -65,7 +65,11 @@ pub fn prewarm_source(path: &Path) -> Result<SourceCacheStatus> {
         return Ok(SourceCacheStatus::Hit);
     }
 
-    let image = image::open(path)?.to_rgba8();
+    let image = ImageReader::open(path)?
+        .with_guessed_format()?
+        .decode()?
+        .to_rgba8();
+
     store_cached_rgba(path, &image)?;
     Ok(SourceCacheStatus::Warmed)
 }
@@ -229,7 +233,11 @@ pub(super) fn load_rgba_image(path: &Path) -> Result<RgbaImage> {
         return Ok(image);
     }
 
-    let image = image::open(path)?.to_rgba8();
+    let image = ImageReader::open(path)?
+        .with_guessed_format()?
+        .decode()?
+        .to_rgba8();
+
     let _ = store_cached_rgba(path, &image);
     Ok(image)
 }

--- a/crates/renderer/src/draw/avatar.rs
+++ b/crates/renderer/src/draw/avatar.rs
@@ -7,7 +7,7 @@ use std::{
     time::UNIX_EPOCH,
 };
 
-use image::{RgbaImage, imageops::FilterType};
+use image::{ImageReader, RgbaImage, imageops::FilterType};
 use tiny_skia::{FillRule, FilterQuality, Mask, PathBuilder, Pixmap, PixmapPaint, Transform};
 
 use crate::{ClearColor, FrameSize, PixelBuffer, RendererError, Result, ShadowStyle};
@@ -100,7 +100,10 @@ impl AvatarAsset {
             return Ok(cached);
         }
 
-        let image = image::open(path)?.to_rgba8();
+        let image = ImageReader::open(path)?
+            .with_guessed_format()?
+            .decode()?
+            .to_rgba8();
         let image = prepare_avatar_image(image);
         let pixmap = rgba_to_pixmap(image)?;
         let _ = store_cached_avatar(path, &pixmap);

--- a/crates/renderer/src/draw/cover.rs
+++ b/crates/renderer/src/draw/cover.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use image::RgbaImage;
+use image::{ImageReader, RgbaImage};
 use tiny_skia::{FillRule, FilterQuality, Mask, PathBuilder, Pixmap, PixmapPaint, Transform};
 
 use crate::{FrameSize, PixelBuffer, RendererError, Result};
@@ -14,7 +14,10 @@ pub enum CoverArtAsset {
 
 impl CoverArtAsset {
     pub fn load(path: &Path) -> Result<Self> {
-        let image = image::open(path)?.to_rgba8();
+        let image = ImageReader::open(path)?
+            .with_guessed_format()?
+            .decode()?
+            .to_rgba8();
         let pixmap = rgba_to_pixmap(image)?;
         Ok(Self::Image(pixmap))
     }


### PR DESCRIPTION
The image crate's `::open` guesses the filename based on the file extension, however chrome for example generates random file names. They do provide the `ImageReader` struct though that can guess file format!

I've replaced all instances of `image::open` with `ImageReader`.