### PR TITLE
fix: fixed flake evaluation warning for post-NixOS 25.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
         }:
         let
           cfg = config.programs.veila;
-          package = self.packages.${pkgs.system}.default;
+          package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         in
         {
           options.programs.veila = {


### PR DESCRIPTION
With the release of v25.11 for NixOS, the alias `pkgs.system` for `pkgs.stdenv.hostPlatform.system` was removed for clarity regarding cross-compilation.

This commit fixes that evaluation error by replacing the alias in the default package declaration.

NixOS/nixpkgs@90cb787