### PR TITLE
feat: nix home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/naurissteins/veila?style=for-the-badge&labelColor=181825&color=f9e2af)
 
 Veila is built for wlroots-style compositors like labwc, Niri, Hyprland, Sway, MangoWC and others that support the Wayland ext-session-lock-v1 protocol. Its main goal is to provide a secure, fast and elegant lock screen without relying on heavyweight UI stacks.
+
 </div>
 
 <a href="https://github.com/user-attachments/assets/3b523594-dc4e-428e-8564-a619148973ee" target="_blank">
@@ -25,7 +26,7 @@ Veila is built for wlroots-style compositors like labwc, Niri, Hyprland, Sway, M
 
 </div>
 
-----
+---
 
 ## 🔥 Features
 
@@ -40,7 +41,9 @@ Veila is built for wlroots-style compositors like labwc, Niri, Hyprland, Sway, M
 - Lightweight design without a heavy desktop UI toolkit
 
 ## Install
+
 ### Arch Linux
+
 On Arch Linux, install Veila from the AUR:
 
 ```bash
@@ -112,6 +115,36 @@ Add PAM service:
   security.pam.services.veila = {};
 }
 ```
+
+**Home Manager:**
+
+Import `veila.homeModules.default` to install Veila and manage the config file and user services.
+
+```nix
+{
+  imports = [ veila.homeModules.default ];
+
+  programs.veila = {
+    enable = true;
+    service.enable = true;
+    settings = {
+      theme = "santorini";
+    };
+    idle = {
+      enable = true;
+      lockAfter = 300;
+      lockBeforeSleep = true;
+    };
+  };
+}
+```
+
+> [!IMPORTANT]
+> Home Manager cannot set up PAM, so password unlock needs one line in your system (NixOS) configuration:
+>
+> ```nix
+> security.pam.services.veila = {};
+> ```
 
 ## Docs
 

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,100 @@
           };
         };
 
+      homeModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.veila;
+          tomlFormat = pkgs.formats.toml { };
+        in
+        {
+          options.programs.veila = {
+            enable = lib.mkEnableOption "Veila screen locker";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              defaultText = lib.literalExpression "inputs.veila.packages.\${pkgs.system}.default";
+              description = "Veila package to install.";
+            };
+
+            settings = lib.mkOption {
+              type = tomlFormat.type;
+              default = { };
+              example = lib.literalExpression ''{ theme = "santorini"; }'';
+              description = "Written verbatim as TOML to ~/.config/veila/config.toml.";
+            };
+
+            service.enable = lib.mkEnableOption "the veilad daemon as a systemd user service";
+
+            idle = {
+              enable = lib.mkEnableOption "the veila idle/sleep auto-lock helper";
+
+              lockAfter = lib.mkOption {
+                type = lib.types.ints.positive;
+                default = 300;
+                description = "Seconds of inactivity before locking.";
+              };
+
+              lockBeforeSleep = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Also lock before the system goes to sleep.";
+              };
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+
+            xdg.configFile."veila/config.toml" = lib.mkIf (cfg.settings != { }) {
+              source = tomlFormat.generate "veila-config.toml" cfg.settings;
+            };
+
+            systemd.user.services.veilad = lib.mkIf cfg.service.enable {
+              Unit = {
+                Description = "Veila screen locker daemon";
+                After = [ "graphical-session.target" ];
+                PartOf = [ "graphical-session.target" ];
+              };
+              Service = {
+                Type = "simple";
+                ExecStart = "${cfg.package}/bin/veilad";
+                Restart = "on-failure";
+                RestartSec = 2;
+                PassEnvironment = "WAYLAND_DISPLAY XDG_SESSION_ID XDG_SESSION_TYPE XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK NIRI_SOCKET";
+              };
+              Install.WantedBy = [ "graphical-session.target" ];
+            };
+
+            systemd.user.services.veila-idle = lib.mkIf cfg.idle.enable {
+              Unit = {
+                Description = "Veila idle and sleep lock monitor";
+                After = [
+                  "graphical-session.target"
+                  "veilad.service"
+                ];
+                PartOf = [ "graphical-session.target" ];
+              };
+              Service = {
+                Type = "simple";
+                ExecStart =
+                  "${cfg.package}/bin/veila idle --lock-after=${toString cfg.idle.lockAfter}"
+                  + lib.optionalString cfg.idle.lockBeforeSleep " --lock-before-sleep";
+                Restart = "on-failure";
+                RestartSec = 2;
+                PassEnvironment = "WAYLAND_DISPLAY XDG_SESSION_ID XDG_SESSION_TYPE XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK NIRI_SOCKET";
+              };
+              Install.WantedBy = [ "graphical-session.target" ];
+            };
+          };
+        };
+
       apps = forAllSystems (
         system:
         let


### PR DESCRIPTION
I've been using veila now for a little bit in my NixOS setup and I really like it! But when I changed to home-manager I noticed that it was missing from the `flake.nix` file. So here is my attempt of adding it so people can enable it and configure it with home manager :)